### PR TITLE
Add support for OSSELOT_IGNORE

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,10 @@ Additionally, you can customize the output directory for Osselot results by sett
 
 There might be false negatives when matching packages against the Osselot API due to mismatch in name or version formatting between the recipe and the Osselot database. In these cases you can set the variables `OSSELOT_NAME` and `OSSELOT_VERSION` within your recipe. If the mismatch occurs within an upstream recipe from the openembedded-core layer, please fix this by submitting a bbappend file to this repository.
 
+## Excluding packages from Osselot
+
+You can opt to exclude packages from Osselot by setting `OSSELOT_IGNORE = "1"` within a recipe.
+
 ##  Contributing
 
 Please submit any patches against the meta-osselot layer via a GitHub Pull Request.

--- a/recipes-core/images/core-image-minimal%.bbappend
+++ b/recipes-core/images/core-image-minimal%.bbappend
@@ -1,0 +1,4 @@
+# SPDX-License-Identifier: MIT
+# Copyright 2023 iris-GmbH infrared & intelligent sensors
+
+OSSELOT_IGNORE = "1"


### PR DESCRIPTION
It is now possible to ignore packages by setting the OSSELOT_IGNORE variable to true within the recipe.

Fixes: https://github.com/iris-GmbH/meta-osselot/issues/4