### PR TITLE
Revert "Limit osselot deploy folder creation to BPN"

### DIFF
--- a/classes/osselot.bbclass
+++ b/classes/osselot.bbclass
@@ -75,7 +75,7 @@ python do_osselot_collect() {
 
     osselot_package_data_path = os.path.abspath(f"{osselot_data_dir_s}/analysed-packages/{osselot_name}")
     osselot_versioned_package_data_path = os.path.abspath(f"{osselot_package_data_path}/version-{osselot_version}")
-    osselot_package_deploy_dir = os.path.abspath(f"{osselot_deploy_dir}/{bpn}")
+    osselot_package_deploy_dir = os.path.abspath(f"{osselot_deploy_dir}/{pn}")
     osselot_versioned_package_deploy_dir = os.path.abspath(f"{osselot_package_deploy_dir}/{osselot_version}")
 
     # check for yocto patches
@@ -124,7 +124,7 @@ python do_osselot_collect() {
 addtask osselot_collect after do_unpack
 do_osselot_collect[nostamp] = "1"
 do_osselot_collect[dirs] = "${OSSELOT_DEPLOY_DIR}"
-do_osselot_collect[cleandirs] = "${OSSELOT_DEPLOY_DIR}/${BPN}"
+do_osselot_collect[cleandirs] = "${OSSELOT_DEPLOY_DIR}/${PN}"
 do_osselot_collect[lockfiles] = "${OSSELOT_META_FILE_LOCK}"
 do_osselot_collect[depends] = "osselot-package-analysis-native:do_unpack"
 do_rootfs[recrdeptask] += "do_osselot_collect"


### PR DESCRIPTION
Reverts iris-GmbH/meta-osselot#19

This caused multiple recipe tasks (e.g. target, native) to run "cleandirs" on the same folder, effectively causing the native taks to delete the collected data from the target task.